### PR TITLE
match variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Ex:
 
 | variable                              | description                                                                                            | default                    |
 |---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|----------------------------|
-| `g:vim_uue_plugin_load_full_syntax`\* | enable: load all syntax files in `runtimepath`. disable: only in `syntax`, `~/.vim/syntax` and `$VIM/vimfiles/syntax` | 0                          |
-| `g:vim_uue_plugin_use_pug`\*          | enable `vim-pug` pug syntax for `<template lang="pug">`.                                               | 0                          |
+| `g:vim_vue_plugin_load_full_syntax`\* | enable: load all syntax files in `runtimepath`. disable: only in `syntax`, `~/.vim/syntax` and `$VIM/vimfiles/syntax` | 0                          |
+| `g:vim_vue_plugin_use_pug`\*          | enable `vim-pug` pug syntax for `<template lang="pug">`.                                               | 0                          |
 | `g:vim_vue_plugin_debug`              | echo debug message in `messages` list. Useful to debug if indent errors occur.                         | 0                          |
 | `g:vim_vue_plugin_has_init_indent`    | initially indent one tab inside `style/script` tags.                                                   | 0 for `.vue`. 1 for `.wpy` |
 


### PR DESCRIPTION
believe an error with the variable names spelling, "u" instead of "v"